### PR TITLE
Added .gitignore updated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,40 @@
+# Ignore environment files
 .env
+.env.*
+
+# Ignore sensitive JS config
 components/firebaseauth.js
+
+# Node modules
+node_modules/
+
+# Build output
+dist/
+build/
+
+# System files
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+
+# VS Code settings
+.vscode/
+
+# OS generated files
+*.swp
+*.swo
+
+# Temp files
+temp/
+
+# Firebase local emulators
+.firebase/
+
+# Misc
+*.bak
+*.tmp
+
+# Ignore screenshots if not needed in repo
+# assets/screenshots/


### PR DESCRIPTION
A proper .gitignore has been added and now includes common ignores for environment files, node modules, build output, editor/system files, logs, temp files, and more. This will help keep your repository clean and secure.