### PR TITLE
Add Navigation Button to Main Home Page

### DIFF
--- a/components/about.html
+++ b/components/about.html
@@ -65,6 +65,7 @@
     <hr />
     <div style="display: flex; justify-content: flex-start; max-width: 800px; margin: 0 auto 24px auto;">
       <a href="homepage.html" class="about-btn">&#8592; Back to Home</a>
+      <a href="../index.html" class="about-btn" style="margin-left: 0.5rem;">&#8592; Back to Main Home</a>
     </div>
     <div class="main-content" style="padding: 32px 16px; max-width: 800px; margin: 0 auto;">
         <div class="para">

--- a/components/employer.html
+++ b/components/employer.html
@@ -61,6 +61,7 @@
     <div class="headContainer">
       <img src="../assets/logo.webp" alt="Job Junction logo" loading="lazy" />
       <div class="headlinks">
+        <a href="../index.html">Main Home</a>
         <a href="about.html" target="_blank">About</a>
         <a href="homepage.html">Home</a>
         <button class="req">Requests</button>

--- a/components/seeker.html
+++ b/components/seeker.html
@@ -63,6 +63,7 @@
     <img src="../assets/logo.webp" alt="Job Junction logo" loading="lazy" class="logo" />
 
     <nav class="headlinks">
+        <a href="../index.html">Main Home</a>
       <a href="../components/about.html" target="_self">About</a>
       <a href="../components/homepage.html">Home</a>
       <button class="apply-btn">Apply</button>


### PR DESCRIPTION
# Pull Request

## Description
This pull request adds a navigation button labeled "Main Home" to the `seeker.html`, `employer.html`, and `about.html` pages. The button allows users to navigate back to the main home page (`index.html`) from any of these internal pages. This improves user experience by providing consistent and easy access to the main landing page.

Fixes #137 

<br>
<img width="400" height="92" alt="image" src="https://github.com/user-attachments/assets/5e2c3ea7-8151-46da-98ea-fd27b379ff17" />
<br><br>
<img width="400" height="106" alt="image" src="https://github.com/user-attachments/assets/23089205-168e-4dca-8912-35c96992c4b9" />
<br><br>
<img width="400" height="127" alt="image" src="https://github.com/user-attachments/assets/42451d69-9dfa-4374-8e5f-4e5039be8e47" />
