### PR TITLE
Style navigation and text links properly

### DIFF
--- a/index.html
+++ b/index.html
@@ -482,6 +482,49 @@
     --footer-bg: #232a36;
     --footer-text: #f7f9fc;
   }
+  /* Navigation Links Styling */
+.nav-menu,
+.navbar-links {
+  display: flex;
+  gap: 1.5rem; /* even spacing between links */
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.nav-link,
+.navbar-links a {
+  text-decoration: none;
+  color: #222; /* default dark text */
+  font-family: 'Inter', sans-serif;
+  font-weight: 500;
+  position: relative;
+  transition: color 0.3s ease;
+}
+
+/* Hover underline animation */
+.nav-link::after,
+.navbar-links a::after {
+  content: "";
+  position: absolute;
+  bottom: -4px;
+  left: 0;
+  width: 0%;
+  height: 2px;
+  background-color: #3d55b4; /* primary accent color */
+  transition: width 0.3s ease;
+}
+
+.nav-link:hover,
+.navbar-links a:hover {
+  color: #3d55b4; /* text color change */
+}
+
+.nav-link:hover::after,
+.navbar-links a:hover::after {
+  width: 100%; /* underline expands smoothly */
+}
+
 </style>
 
 <script>


### PR DESCRIPTION
# Pull Request

## Description
Navigation links (Home, Jobs, Contact, etc.) are plain blue underlined text, giving an unstyled and outdated feel.

Suggested Solution:

Apply custom font styles
Add hover effects (e.g., underline on hover or color transition)
Use flex layout to space them evenly
Why it matters:

Makes navigation cleaner and modern
Increases user trust and engagement


Fixes #179 

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
