### PR TITLE
Fix the footer alignment

### DIFF
--- a/components/seeker.html
+++ b/components/seeker.html
@@ -161,7 +161,7 @@
             <p>Connecting Talent with Opportunity . Your Career Journey Starts Here!</p>
 
         </div>
-        <div>
+        <div style="align-items: center; margin-left: 18rem;">
             <div class="footer-links">
                 <h3>
                     For Job Seekers


### PR DESCRIPTION
## Description
Aligned the footer content on the Seeker’s page in center. 
There was a noticeable difference in spacing between the left and right sides, making the footer look off-center.

### Fixes: #236

### Type of change
- [x] Bug fix
