### PR TITLE
Remove duplicate search box

### DIFF
--- a/components/seeker.html
+++ b/components/seeker.html
@@ -120,20 +120,7 @@
                 <option value="900">$900+/m</option>
                 <option value="1200">$1200+/m</option>
             </select>
-        </div>
-
-        <input type="text" id="searchInput" class="search-bar fancy-input" placeholder=" Search by position..."
-            style="margin-left: 33rem;" />
-
-        <select id="salaryFilter" class="filter-dropdown fancy-select">
-            <option value=""> All Salaries</option>
-            <option value="500">$500+/m</option>
-            <option value="900">$900+/m</option>
-            <option value="1200">$1200+/m</option>
-        </select>
-    </div>
-
-
+          </div>
     <div class="jobs-container">
 
     </div>


### PR DESCRIPTION
### Description
This PR removes the duplicate search box that was being rendered on the page.  
The duplication occurred due to overlapping components, resulting in multiple search inputs.

### Fixes: #348

### Changes Made
- Removed the extra search box from the UI.
- Cleaned up unused code related to the duplicate component.
- Ensured consistent rendering of the single search box.

### Testing
- Verified that only one search box is visible across all relevant pages.
- Confirmed that search functionality works as expected.
