### PR TITLE
Remove multiple Home navigations

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -197,7 +197,6 @@
     <h1>Frequently Asked Questions</h1>
      <i class="fa-solid fa-circle-question" id="question-icon"></i>
     <p>Find answers to common questions about Job Junction</p>
-  <div><a href="index.html" class="home-btn"><i class="fa-solid fa-house"></i> Home</a></div>
   </header>
 
   <!-- Search -->


### PR DESCRIPTION
Pull Request
Description

This PR resolves the issue of multiple "Home" navigation links appearing on the FAQ page. The redundant navigation elements have been removed, and the layout has been updated to ensure consistent navigation behavior across all pages.
Additionally, the FAQ page has been tested to confirm that only a single "Home" link is now displayed, improving user experience and visual consistency.

Fixes: #652

Type of Change
 Bug fix (non-breaking change which fixes an issue)
 New feature (non-breaking change which adds functionality)
 Breaking change (fix or feature that would cause existing functionality to not work as expected)
 Documentation update

Rationale
The duplication of "Home" navigation links on the FAQ page created UI inconsistency and confusion for users. This fix ensures a clean and uniform navigation structure throughout the website.

Checklist
 My code follows the style guidelines of this project
 I have performed a self-review of my own code
 I have commented my code, particularly in hard-to-understand areas