### PR TITLE
redirecting to about page

### DIFF
--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -253,7 +253,7 @@ body.dark-mode .dropdown-menu a:hover {
         </div>
       </div>
       <a href="companies.html">Companies</a>
-      <a href="about.html">About</a>
+      <a href="about-us.html">About</a>
       <a href="ContactPage.html">Contact</a>
     </nav>
     <button class="theme-toggle" id="themeToggle">🌓</button>


### PR DESCRIPTION
# Pull Request

## Description
The about in nav bar was not redirecting to about-us page, now it is working.

Fixes #649 

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
